### PR TITLE
Do not allow multiple tagged commands to be issued at the same time

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -740,6 +740,10 @@ IMAPClient.prototype._processCommandQueue = function(){
         setTimeout(this._processCommandQueue.bind(this), 100);
         return;
     }
+    
+    if (this._currentRequest && this._currentRequest.hasCallback) {
+        return;
+    }
 
     var command = this._commandQueue.shift();
 
@@ -754,7 +758,9 @@ IMAPClient.prototype._processCommandQueue = function(){
         console.log("CLIENT: "+ (command.data || "").trim());
     }
 
+    var hasCallback = typeof command.callback == "function";
     this._currentRequest = {
+        hasCallback: hasCallback,
         tag: command.tag,
         callback: (function(status, params){
 
@@ -764,7 +770,7 @@ IMAPClient.prototype._processCommandQueue = function(){
                 this._shouldIdleTimer = setTimeout(this.idle.bind(this), this.ENTER_IDLE);
             }
 
-            if(typeof command.callback == "function"){
+            if (hasCallback) {
                 command.callback(status, params);
             }
             this._currentRequest = false;


### PR DESCRIPTION
Before that it was possible for currentRequest to be overwritten, which resulted in the callback never being called, even though response would come