### PR TITLE
Add greeting timeout to options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ where
   * **options.auth.XOAuthToken** (optional) is either a String or *inbox.createXOAuthGenerator* object
   * **options.clientId** is optional client ID params object
   * **options.clientId.name** is is the name param etc. see [rfc 2971](http://tools.ietf.org/html/rfc2971#section-3.3) for possible field names
+  * **options.greetingTimeout** is the timeout for the initial connection to the server in ms, default: 15 seconds.
 
 Example:
 ```javascript

--- a/lib/client.js
+++ b/lib/client.js
@@ -89,6 +89,13 @@ function IMAPClient(port, host, options){
     this.host = host || "localhost";
 
     /**
+     * If greetingTimeout is set, overwrite the local setting.
+     */
+    if (!!options.greetingTimeout){ 
+        this.GREETING_TIMEOUT = options.greetingTimeout;
+    }
+
+    /**
      * If set to true, print traffic between client and server to the console
      */
     this.debug = !!this.options.debug;


### PR DESCRIPTION
My server would oftentimes take longer than 15s to greet, thus this setting was annoying.
Now you can add this setting to the options.

If you want tests, please propose a way to test this.

Signed-off-by: Armin Hueneburg <hueneburg.armin@gmail.com>